### PR TITLE
fix: Fix signal handling so shutdown works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,21 +10,19 @@ ARG vs_version=1.21.6
 RUN apk update
 RUN apk add wget tar
 
-RUN wget "https://cdn.vintagestory.at/gamefiles/${vs_type}/vs_server_${vs_os}_${vs_version}.tar.gz"
-RUN tar -xvzf "vs_server_${vs_os}_${vs_version}.tar.gz"
-RUN rm "vs_server_${vs_os}_${vs_version}.tar.gz"
+RUN wget "https://cdn.vintagestory.at/gamefiles/${vs_type}/vs_server_${vs_os}_${vs_version}.tar.gz" && \
+  tar -xvzf "vs_server_${vs_os}_${vs_version}.tar.gz" && \
+  rm "vs_server_${vs_os}_${vs_version}.tar.gz"
 
 # ============== runtime stage ==================
-FROM mcr.microsoft.com/dotnet/sdk:8.0 as runtime
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS runtime
 WORKDIR /game
 # Defaults
 ENV VS_DATA_PATH=/gamedata/vs
 COPY --from=downloader "./download/" "/game"
+COPY entrypoint.sh "/game"
 
 #  Expose ports
 EXPOSE 42420
 
-# see https://docs.docker.com/reference/build-checks/json-args-recommended/
-SHELL [ "/bin/bash", "-c" ]
-# Execution command
-ENTRYPOINT dotnet VintagestoryServer.dll --dataPath $VS_DATA_PATH
+CMD ["/game/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec dotnet VintagestoryServer.dll --dataPath $VS_DATA_PATH "$@"


### PR DESCRIPTION
Currently the vs server process never gets signals because bash is pid 1.  Changing things to use an exec call gets signals working again.